### PR TITLE
switch to neon-http driver

### DIFF
--- a/neon-cloudflare/src/index.ts
+++ b/neon-cloudflare/src/index.ts
@@ -1,7 +1,7 @@
-import { Client } from '@neondatabase/serverless'
+import { neon } from '@neondatabase/serverless'
 import { eq } from 'drizzle-orm/expressions'
 import type { NeonDatabase } from 'drizzle-orm/neon-serverless'
-import { drizzle } from 'drizzle-orm/neon-serverless'
+import { drizzle } from 'drizzle-orm/neon-http';
 import type { IRequest as IttyRequest, RequestLike, Route } from 'itty-router'
 
 import {
@@ -18,7 +18,6 @@ interface Env {
 }
 
 interface Request extends IttyRequest {
-  client: Client
   db: NeonDatabase
 }
 
@@ -28,9 +27,7 @@ interface Methods {
 }
 
 async function injectDB(request: Request, env: Env) {
-  request.client = new Client(env.NEON_DATABASE_URL)
-  request.db = drizzle(request.client)
-  request.client.connect()
+  request.db = drizzle(neon(env.NEON_DATABASE_URL))
 }
 
 const router = Router<Request, any[]>({ base: '/' })


### PR DESCRIPTION
The Neon websocket driver is not suitable for 1 query per request. Because of limitations by cloudflare, the websocket connection cannot be cached and re-used between requests, which means each request needs to make 4 round trips to establish a new connection.

Switching to the Neon HTTP driver instead supports caching the connections (both on cloudflare's side and also on Neon's side) which makes it a lot more efficient. Turso and Planetscale are also using HTTP based drivers internally

Things to note: 
* The HTTP driver does not yet support interactive transactions, while the WS driver does. We're planning to remove this limitation soon, although we have not had much signal to imply that it's necessary yet. HTTP driver does support batch queries inside a transaction.
* Because of this confusion between HTTP and WS drivers, we're planning to consolidate the API, so you won't have to choose between the two for the good default option